### PR TITLE
changed name of the list item

### DIFF
--- a/R/import_list.R
+++ b/R/import_list.R
@@ -12,7 +12,7 @@
 #' library('datasets')
 #' export(list(mtcars1 = mtcars[1:10,], 
 #'             mtcars2 = mtcars[11:20,],
-#'             mtcars2 = mtcars[21:32,]), "mtcars.xlsx")
+#'             mtcars3 = mtcars[21:32,]), "mtcars.xlsx")
 #' 
 #' # import a single file from multi-object workbook
 #' str(import("mtcars.xlsx", which = "mtcars1"))


### PR DESCRIPTION
two identical names are forbidden in an excel file

I submit the PR because with the changes an error is thrown during the checks with the updated openxlsx package.

in the example you tried to create two sheets with the identical name, which was possible in the past, but results in an error in the current version.