### PR TITLE
Remove the obsolete data.table option change

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Imports:
     foreign,
     haven (>= 1.1.2),
     curl (>= 0.6),
-    data.table (>= 1.9.8),
+    data.table (>= 1.11.2),
     readxl (>= 0.1.1),
     openxlsx,
     tibble

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+* Unexport objects: `.import`, `.export`; remove documentation for `arg_reconcile` #321
+* Declutter
+   - remove the obsolete data.table option #323
+
 # rio 0.5.30
 
 * Maintenance release: new maintainer

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -1,7 +1,3 @@
-.onLoad <- function(libname, pkgname) {
-    options(datatable.fread.dec.experiment=FALSE)
-}
-
 .onAttach <- function(libname, pkgname) {
     if (interactive()) {
         w <- uninstalled_formats()


### PR DESCRIPTION
It has been removed since 2018

https://github.com/Rdatatable/data.table/blob/88039186915028ab3c93ccfd8e22c0d1c3534b1a/NEWS.md?plain=1#L1797